### PR TITLE
Fix an error if the template does not contain variables

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/jiren/cli.py
+++ b/jiren/cli.py
@@ -25,7 +25,10 @@ class Application:
             var_group.add_argument("--var." + v)
         args = var_parser.parse_args()
 
-        variables = {k: v for k, v in vars(args.var).items() if v is not None}
+        if "var" in args:
+            variables = {k: v for k, v in vars(args.var).items() if v is not None}
+        else:
+            variables = {}
         print(template.render(**variables))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,10 @@ import tempfile
 
 import pytest
 
-from jiren.cli import main
+from jiren.cli import Application, main
 
 
-class TestCLI:
+class TestApplication:
     @pytest.mark.parametrize(
         "inputs,argv,expected",
         [
@@ -16,7 +16,7 @@ class TestCLI:
             ("{{ greeting | default('hi') }}", [], "hi\n"),
         ],
     )
-    def test_main(self, monkeypatch, inputs, argv, expected):
+    def test_run(self, monkeypatch, inputs, argv, expected):
         argv = ["jiren"] + argv
         stdin = io.StringIO(inputs)
         stdout = io.StringIO()
@@ -25,16 +25,15 @@ class TestCLI:
             m.setattr("sys.argv", argv)
             m.setattr("sys.stdin", stdin)
             m.setattr("sys.stdout", stdout)
-            main()
+            Application().run()
 
-        actual = stdout.getvalue()
-        assert expected == actual
+        assert stdout.getvalue() == expected
 
     @pytest.mark.parametrize(
         "inputs,argv,expected",
         [("{{ greeting }}", ["--var.greeting=hello"], "hello\n")],
     )
-    def test_main_with_infile(self, monkeypatch, inputs, argv, expected):
+    def test_run_with_infile(self, monkeypatch, inputs, argv, expected):
         template_dir = tempfile.TemporaryDirectory(prefix="jiren-")
         template_file = os.path.join(template_dir.name, "template.j2")
         with open(template_file, "w") as f:
@@ -46,7 +45,21 @@ class TestCLI:
         with monkeypatch.context() as m:
             m.setattr("sys.argv", argv)
             m.setattr("sys.stdout", stdout)
+            Application().run()
+
+        assert stdout.getvalue() == expected
+
+
+class TestCLI:
+    def test_main(self, monkeypatch):
+        argv = ["jiren", "--var.greeting=hello"]
+        stdin = io.StringIO("{{ greeting }}")
+        stdout = io.StringIO()
+
+        with monkeypatch.context() as m:
+            m.setattr("sys.argv", argv)
+            m.setattr("sys.stdin", stdin)
+            m.setattr("sys.stdout", stdout)
             main()
 
-        actual = stdout.getvalue()
-        assert expected == actual
+        assert stdout.getvalue() == "hello\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ class TestApplication:
             ("{{ greeting }}", ["--var.greeting=hello"], "hello\n"),
             ("{{ greeting }}", [], "\n"),
             ("{{ greeting | default('hi') }}", [], "hi\n"),
+            ("hello", [], "hello\n"),
+            ("", [], "\n"),
         ],
     )
     def test_run(self, monkeypatch, inputs, argv, expected):


### PR DESCRIPTION
```
echo "" | jiren
```
```
Traceback (most recent call last):
  File "/Users/speg03/.local/src/github.com/speg03/jiren/.venv/jiren-dev/bin/jiren", line 11, in <module>
    load_entry_point('jiren', 'console_scripts', 'jiren')()
  File "/Users/speg03/.local/src/github.com/speg03/jiren/jiren/cli.py", line 35, in main
    Application().run()
  File "/Users/speg03/.local/src/github.com/speg03/jiren/jiren/cli.py", line 30, in run
    variables = {k: v for k, v in vars(args.var).items() if v is not None}
AttributeError: 'NestedNamespace' object has no attribute 'var'
```