### PR TITLE
Add strict option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,7 +45,7 @@ jiren template.j2 --var.name=world
 hello, world
 ```
 
-この例では、テンプレートに `name` という変数が含まれています。 `jiren` コマンドに渡すプログラム引数を使って、テンプレート内の変数に値を設定できます。プログラム引数の名前は先頭に `--var.` をつける必要があることに注意してください。
+この例では、テンプレートに `name` という変数が含まれています。 `jiren` コマンドに渡すプログラム引数を使って、テンプレート内の変数に値を指定できます。プログラム引数の名前は先頭に `--var.` をつける必要があることに注意してください。
 
 テンプレートの書式について詳しく知りたい場合は、jinja2のドキュメント ( http://jinja.pocoo.org/ ) を参照してください。
 
@@ -56,21 +56,43 @@ hello, world
 
 コマンド:
 ```sh
-echo "hello, {{ name }}" | jiren --help
+echo "{{ greeting }}, {{ name }}" | jiren --help
 ```
 出力:
 ```
-usage: jiren [-h] [--var.name VAR.NAME] [template]
-
-Generate text from a template
-
-positional arguments:
-  template             Template file path. If omitted, read a template from
-                       stdin.
-
-optional arguments:
-  -h, --help           show this help message and exit
+... （中略）
 
 variables:
   --var.name VAR.NAME
+  --var.greeting VAR.GREETING
+```
+
+
+### 変数のデフォルト値
+
+値が指定されなかった変数に対して、デフォルト値を設定することができます。これはjinja2の仕様に基づきます。
+
+コマンド:
+```sh
+echo "{{ greeting }}, {{ name | default('world') }}" | jiren --var.greeting=hello
+```
+出力:
+```
+hello, world
+```
+
+
+### strictオプション
+
+`--strict` オプションを使うと、すべての変数の値を必ず指定しなければいけません。
+
+コマンド:
+```sh
+echo "{{ greeting }}, {{ name }}" | jiren --strict --var.greeting=hello
+```
+出力:
+```
+... （中略）
+
+jiren: error: the following arguments are required: --var.name
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Command:
 ```sh
 echo "hello, {{ name }}" | jiren --var.name=world
 ```
-Output:
+Outputs:
 ```
 hello, world
 ```
@@ -42,7 +42,7 @@ EOF
 
 jiren template.j2 --var.name=world
 ```
-Output:
+Outputs:
 ```
 hello, world
 ```
@@ -58,21 +58,43 @@ You can use the help to check the variables defined in a template.
 
 Command:
 ```sh
-echo "hello, {{ name }}" | jiren --help
+echo "{{ greeting }}, {{ name }}" | jiren --help
 ```
-Output:
+Outputs:
 ```
-usage: jiren [-h] [--var.name VAR.NAME] [template]
-
-Generate text from a template
-
-positional arguments:
-  template             Template file path. If omitted, read a template from
-                       stdin.
-
-optional arguments:
-  -h, --help           show this help message and exit
+... (omitted)
 
 variables:
   --var.name VAR.NAME
+  --var.greeting VAR.GREETING
+```
+
+
+### Default values
+
+You can set default values for variables for which no values was specified. This is based on the jinja2 specification.
+
+Command:
+```sh
+echo "{{ greeting }}, {{ name | default('world') }}" | jiren --var.greeting=hello
+```
+Outputs:
+```
+hello, world
+```
+
+
+### Strict option
+
+When using the `--strict` option, you must specify values for all variables.
+
+Command:
+```sh
+echo "{{ greeting }}, {{ name }}" | jiren --strict --var.greeting=hello
+```
+Outputs:
+```
+... (omitted)
+
+jiren: error: the following arguments are required: --var.name
 ```

--- a/jiren/cli.py
+++ b/jiren/cli.py
@@ -14,6 +14,12 @@ class Application:
             nargs="?",
             help="Template file path. If omitted, read a template from stdin.",
         )
+        pre_parser.add_argument(
+            "-s",
+            "--strict",
+            action="store_true",
+            help="You must specify values for all variables.",
+        )
         pre_args, _ = pre_parser.parse_known_args()
 
         if pre_args.template:
@@ -29,7 +35,7 @@ class Application:
         )
         var_group = parser.add_argument_group("variables")
         for v in template.variables:
-            var_group.add_argument("--var." + v)
+            var_group.add_argument("--var." + v, required=pre_args.strict)
         args = parser.parse_args()
 
         if "var" in args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ class TestApplication:
         "inputs,argv,expected",
         [
             ("{{ greeting }}", ["--var.greeting=hello"], "hello\n"),
+            ("{{ greeting }}", ["--strict", "--var.greeting=hello"], "hello\n"),
             ("{{ greeting }}", [], "\n"),
             ("{{ greeting | default('hi') }}", [], "hi\n"),
             ("hello", [], "hello\n"),
@@ -50,6 +51,22 @@ class TestApplication:
             Application().run()
 
         assert stdout.getvalue() == expected
+
+    def test_run_strictly(self, monkeypatch):
+        argv = ["jiren", "--strict"]
+        stdin = io.StringIO("{{ greeting }}")
+        stderr = io.StringIO()
+
+        with monkeypatch.context() as m:
+            m.setattr("sys.argv", argv)
+            m.setattr("sys.stdin", stdin)
+            m.setattr("sys.stderr", stderr)
+
+            with pytest.raises(SystemExit):
+                Application().run()
+
+        expected = "jiren: error: the following arguments are required: --var.greeting"
+        assert expected in stderr.getvalue()
 
 
 class TestCLI:


### PR DESCRIPTION
When using the `--strict` option, you must specify values for all variables in a template.