### PR TITLE
Get a version from the package metadata

### DIFF
--- a/jiren/__init__.py
+++ b/jiren/__init__.py
@@ -1,3 +1,8 @@
-__version__ = "0.2.2"
-
 from .template import Template  # noqa: F401
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+__version__ = version("jiren")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 python = "^3.5"
 jinja2 = "^2.10"
 nestargs = "^0.4.0"
+importlib-metadata = { version = "^1.5", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.1"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,6 @@
+import jiren
+
+
+class TestInit:
+    def test_version(self):
+        assert jiren.__version__


### PR DESCRIPTION
If you use Python 3.8 or upper, get a version from `importlib.metadata`. Otherwise, from `importlib_metadata`.