### PR TITLE
Use a double-dash argument

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ pip install jiren
 
 コマンド:
 ```sh
-echo "hello, {{ name }}" | jiren --var.name=world
+echo "hello, {{ name }}" | jiren -- --name=world
 ```
 出力:
 ```
@@ -38,14 +38,14 @@ cat <<EOF >template.j2
 hello, {{ name }}
 EOF
 
-jiren template.j2 --var.name=world
+jiren -i template.j2 -- --name=world
 ```
 出力:
 ```
 hello, world
 ```
 
-この例では、テンプレートに `name` という変数が含まれています。 `jiren` コマンドに渡すプログラム引数を使って、テンプレート内の変数に値を指定できます。プログラム引数の名前は先頭に `--var.` をつける必要があることに注意してください。
+この例では、テンプレートに `name` という変数が含まれています。 `jiren` コマンドに渡すプログラム引数を使って、テンプレート内の変数に値を指定できます。テンプレート内の変数は `--` より後ろで指定することに注意してください。
 
 テンプレートの書式について詳しく知りたい場合は、jinja2のドキュメント ( http://jinja.pocoo.org/ ) を参照してください。
 
@@ -56,15 +56,15 @@ hello, world
 
 コマンド:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --help
+echo "{{ greeting }}, {{ name }}" | jiren -- --help
 ```
 出力:
 ```
 ... （中略）
 
 variables:
-  --var.name VAR.NAME
-  --var.greeting VAR.GREETING
+  --name NAME
+  --greeting GREETING
 ```
 
 
@@ -74,7 +74,7 @@ variables:
 
 コマンド:
 ```sh
-echo "{{ greeting }}, {{ name | default('world') }}" | jiren --var.greeting=hello
+echo "{{ greeting }}, {{ name | default('world') }}" | jiren -- --greeting=hello
 ```
 出力:
 ```
@@ -88,11 +88,11 @@ hello, world
 
 コマンド:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --strict --var.greeting=hello
+echo "{{ greeting }}, {{ name }}" | jiren --strict -- --greeting=hello
 ```
 出力:
 ```
 ... （中略）
 
-jiren: error: the following arguments are required: --var.name
+jiren: error: the following arguments are required: --name
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An example of reading a template from stdin:
 
 Command:
 ```sh
-echo "hello, {{ name }}" | jiren --var.name=world
+echo "hello, {{ name }}" | jiren -- --name=world
 ```
 Outputs:
 ```
@@ -40,14 +40,14 @@ cat <<EOF >template.j2
 hello, {{ name }}
 EOF
 
-jiren template.j2 --var.name=world
+jiren -i template.j2 -- --name=world
 ```
 Outputs:
 ```
 hello, world
 ```
 
-In this example, the template contains a variable called `name`. You can set values for variables in a template using program arguments passed to the `jiren` command. Note that the program arguments must be prefixed with `--var.`.
+In this example, the template contains a variable called `name`. You can set values for variables in a template using program arguments passed to the `jiren` command. Note that the arguments for the variables must be located after `--`.
 
 If you want to know more about template format, please refer to jinja2 document ( http://jinja.pocoo.org/ ).
 
@@ -58,15 +58,15 @@ You can use the help to check the variables defined in a template.
 
 Command:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --help
+echo "{{ greeting }}, {{ name }}" | jiren -- --help
 ```
 Outputs:
 ```
 ... (omitted)
 
 variables:
-  --var.name VAR.NAME
-  --var.greeting VAR.GREETING
+  --name NAME
+  --greeting GREETING
 ```
 
 
@@ -76,7 +76,7 @@ You can set default values for variables for which no values was specified. This
 
 Command:
 ```sh
-echo "{{ greeting }}, {{ name | default('world') }}" | jiren --var.greeting=hello
+echo "{{ greeting }}, {{ name | default('world') }}" | jiren -- --greeting=hello
 ```
 Outputs:
 ```
@@ -90,11 +90,11 @@ When using the `--strict` option, you must specify values for all variables.
 
 Command:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --strict --var.greeting=hello
+echo "{{ greeting }}, {{ name }}" | jiren --strict -- --greeting=hello
 ```
 Outputs:
 ```
 ... (omitted)
 
-jiren: error: the following arguments are required: --var.name
+jiren: error: the following arguments are required: --name
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.5"
 jinja2 = "^2.11"
-nestargs = "^0.4.2"
 importlib-metadata = { version = "^1.5", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,8 @@ class TestApplication:
     @pytest.mark.parametrize(
         "inputs,argv,expected",
         [
-            ("{{ greeting }}", ["--var.greeting=hello"], "hello\n"),
-            ("{{ greeting }}", ["--strict", "--var.greeting=hello"], "hello\n"),
+            ("{{ greeting }}", ["--", "--greeting=hello"], "hello\n"),
+            ("{{ greeting }}", ["--strict", "--", "--greeting=hello"], "hello\n"),
             ("{{ greeting }}", [], "\n"),
             ("{{ greeting | default('hi') }}", [], "hi\n"),
             ("hello", [], "hello\n"),
@@ -34,7 +34,7 @@ class TestApplication:
 
     @pytest.mark.parametrize(
         "inputs,argv,expected",
-        [("{{ greeting }}", ["--var.greeting=hello"], "hello\n")],
+        [("{{ greeting }}", ["--", "--greeting=hello"], "hello\n")],
     )
     def test_run_with_file(self, monkeypatch, inputs, argv, expected):
         template_dir = TemporaryDirectory(prefix="jiren-")
@@ -42,7 +42,7 @@ class TestApplication:
         with open(template_file, "w") as f:
             f.write(inputs)
 
-        argv = ["jiren", template_file] + argv
+        argv = ["jiren", "--input=" + template_file] + argv
         stdout = io.StringIO()
 
         with monkeypatch.context() as m:
@@ -65,13 +65,13 @@ class TestApplication:
             with pytest.raises(SystemExit):
                 Application().run()
 
-        expected = "jiren: error: the following arguments are required: --var.greeting"
+        expected = "jiren: error: the following arguments are required: --greeting"
         assert expected in stderr.getvalue()
 
 
 class TestCLI:
     def test_main(self, monkeypatch):
-        argv = ["jiren", "--var.greeting=hello"]
+        argv = ["jiren", "--", "--greeting=hello"]
         stdin = io.StringIO("{{ greeting }}")
         stdout = io.StringIO()
 


### PR DESCRIPTION
**This is a breaking change.**

Drop the nestargs dependency. So, use a double dash argument instead of the vars prefix.

Before:
```sh
echo "hello, {{ name }}" | jiren --vars.name=world
```

After:
```sh
echo "hello, {{ name }}" | jiren -- --name=world
```
