### PR TITLE
Rename the option: strict -> required

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,13 +82,13 @@ hello, world
 ```
 
 
-### strictオプション
+### requiredオプション
 
-`--strict` オプションを使うと、すべての変数の値を必ず指定しなければいけません。
+`--required` オプションを使うと、すべての変数の値を必ず指定しなければいけません。
 
 コマンド:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --strict -- --greeting=hello
+echo "{{ greeting }}, {{ name }}" | jiren --required -- --greeting=hello
 ```
 出力:
 ```

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ hello, world
 ```
 
 
-### Strict option
+### Option: required
 
-When using the `--strict` option, you must specify values for all variables.
+When using the `--required` option, you must specify values for all variables.
 
 Command:
 ```sh
-echo "{{ greeting }}, {{ name }}" | jiren --strict -- --greeting=hello
+echo "{{ greeting }}, {{ name }}" | jiren --required -- --greeting=hello
 ```
 Outputs:
 ```

--- a/jiren/cli.py
+++ b/jiren/cli.py
@@ -8,10 +8,9 @@ class Application:
     def run(self):
         command_parser = ArgumentParser()
         command_parser.add_argument(
-            "-s",
-            "--strict",
+            "--required",
             action="store_true",
-            help="You must specify values for all variables.",
+            help="Required the specific values for all variables.",
         )
         command_parser.add_argument(
             "-i",
@@ -34,7 +33,7 @@ class Application:
         variable_parser = ArgumentParser(description="Generate text from a template")
         variable_group = variable_parser.add_argument_group("variables")
         for v in template.variables:
-            variable_group.add_argument("--" + v, required=command_args.strict)
+            variable_group.add_argument("--" + v, required=command_args.required)
         args = variable_parser.parse_args(command_args.variables)
 
         variables = {k: v for k, v in vars(args).items() if v is not None}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ class TestApplication:
         "inputs,argv,expected",
         [
             ("{{ greeting }}", ["--", "--greeting=hello"], "hello\n"),
-            ("{{ greeting }}", ["--strict", "--", "--greeting=hello"], "hello\n"),
+            ("{{ greeting }}", ["--required", "--", "--greeting=hello"], "hello\n"),
             ("{{ greeting }}", [], "\n"),
             ("{{ greeting | default('hi') }}", [], "hi\n"),
             ("hello", [], "hello\n"),
@@ -52,8 +52,8 @@ class TestApplication:
 
         assert stdout.getvalue() == expected
 
-    def test_run_strictly(self, monkeypatch):
-        argv = ["jiren", "--strict"]
+    def test_run_with_required(self, monkeypatch):
+        argv = ["jiren", "--required"]
         stdin = io.StringIO("{{ greeting }}")
         stderr = io.StringIO()
 


### PR DESCRIPTION
The `required` option represents the function better than the `strict` option.