### PR TITLE
Remove the capped version dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.5"
-jinja2 = "^2.11"
-importlib-metadata = { version = "^1.5", python = "<3.8" }
+jinja2 = ">=2.11"
+importlib-metadata = { version = ">=1.5", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"


### PR DESCRIPTION
Capped version dependencies cause conflicts with other packages.