### PR TITLE
Deprecate the input option.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ pip install jiren
 
 コマンド:
 ```sh
-echo "hello, {{ name }}" | jiren --input=- -- --name=world
+echo "hello, {{ name }}" | jiren - -- --name=world
 ```
 出力:
 ```
@@ -38,7 +38,7 @@ cat <<EOF >template.j2
 hello, {{ name }}
 EOF
 
-jiren --input=template.j2 -- --name=world
+jiren template.j2 -- --name=world
 ```
 出力:
 ```
@@ -56,7 +56,7 @@ hello, world
 
 コマンド:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren --input=- --help
+echo "{{ message }}, {{ name }}" | jiren - --help
 ```
 出力:
 ```
@@ -74,7 +74,7 @@ variables:
 
 コマンド:
 ```sh
-echo "{{ message }}, {{ name | default('world') }}" | jiren --input=- -- --message=hello
+echo "{{ message }}, {{ name | default('world') }}" | jiren - -- --message=hello
 ```
 出力:
 ```
@@ -94,7 +94,7 @@ greeting:
   name: world
 EOF
 
-echo "{{ greeting.message }}, {{ greeting.name }}" | jiren --input=- --data=data.yaml
+echo "{{ greeting.message }}, {{ greeting.name }}" | jiren - --data=data.yaml
 ```
 出力:
 ```
@@ -113,7 +113,7 @@ message: hello
 invalid_key: invalid
 EOF
 
-echo "{{ message }}" | jiren --input=- --data=data.yaml --strict
+echo "{{ message }}" | jiren - --data=data.yaml --strict
 ```
 出力:
 ```
@@ -127,7 +127,7 @@ jiren: error: the data file contains unknown variables: invalid_key
 
 コマンド:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren --input=- --required -- --message=hello
+echo "{{ message }}, {{ name }}" | jiren - --required -- --message=hello
 ```
 出力:
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An example of reading a template from stdin:
 
 Command:
 ```sh
-echo "hello, {{ name }}" | jiren --input=- -- --name=world
+echo "hello, {{ name }}" | jiren - -- --name=world
 ```
 Outputs:
 ```
@@ -40,7 +40,7 @@ cat <<EOF >template.j2
 hello, {{ name }}
 EOF
 
-jiren --input=template.j2 -- --name=world
+jiren template.j2 -- --name=world
 ```
 Outputs:
 ```
@@ -58,7 +58,7 @@ You can use the help to check the variables defined in a template.
 
 Command:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren --input=- --help
+echo "{{ message }}, {{ name }}" | jiren - --help
 ```
 Outputs:
 ```
@@ -76,7 +76,7 @@ You can set default values for variables for which no values was specified. This
 
 Command:
 ```sh
-echo "{{ message }}, {{ name | default('world') }}" | jiren --input=- -- --message=hello
+echo "{{ message }}, {{ name | default('world') }}" | jiren - -- --message=hello
 ```
 Outputs:
 ```
@@ -96,7 +96,7 @@ greeting:
   name: world
 EOF
 
-echo "{{ greeting.message }}, {{ greeting.name }}" | jiren --input=- --data=data.yaml
+echo "{{ greeting.message }}, {{ greeting.name }}" | jiren - --data=data.yaml
 ```
 Outputs:
 ```
@@ -115,7 +115,7 @@ message: hello
 invalid_key: invalid
 EOF
 
-echo "{{ message }}" | jiren --input=- --data=data.yaml --strict
+echo "{{ message }}" | jiren - --data=data.yaml --strict
 ```
 Outputs:
 ```
@@ -129,7 +129,7 @@ When using the `--required` option, you must specify values for all variables.
 
 Command:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren --input=- --required -- --message=hello
+echo "{{ message }}, {{ name }}" | jiren - --required -- --message=hello
 ```
 Outputs:
 ```

--- a/src/jiren/cli.py
+++ b/src/jiren/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 import yaml
 
@@ -28,7 +29,10 @@ def main():
         "-i",
         "--input",
         type=argparse.FileType("r"),
-        help='An input template file path. If "-" is provided, use stdin.',
+        help=(
+            "Deprecated. Use the template argument instead. "
+            'An input template file path. If "-" is provided, use stdin.'
+        ),
     )
     parser.add_argument(
         "-d",
@@ -36,17 +40,38 @@ def main():
         type=argparse.FileType("r"),
         help="A structured data file path. Accepts JSON or YAML files.",
     )
+    # TODO: Change the template argument to FileType when removing the input option.
+    parser.add_argument(
+        "template",
+        nargs="?",
+        help='A template file path. If "-" is provided, use stdin.',
+    )
     parser.add_argument(
         "variables", nargs="*", help='"--" followed by options for variables.'
     )
     args = parser.parse_args()
 
+    template_source = None
+    variable_options = args.variables
+    # If the deprecated input option is used, the template argument is considered to be
+    # the first of the variables argument.
+    if args.input:
+        template_source = args.input.read()
+        if args.template is not None:
+            variable_options = [args.template]
+            variable_options.extend(args.variables)
+    elif args.template == "-":
+        template_source = sys.stdin.read()
+    elif args.template:
+        with open(args.template, "r") as f:
+            template_source = f.read()
+
     variable_parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS)
     variable_group = variable_parser.add_argument_group("variables")
 
     template = None
-    if args.input:
-        template = Template(args.input.read())
+    if template_source is not None:
+        template = Template(template_source)
         for v in template.variables:
             sanitized_name = v.replace("_", "-").strip("-")
             variable_group.add_argument(f"--{sanitized_name}", dest=v)
@@ -77,7 +102,7 @@ def main():
         )
 
     # Load variables from command line arguments.
-    variable_args = variable_parser.parse_args(args.variables or [])
+    variable_args = variable_parser.parse_args(variable_options)
     variables = {k: v for k, v in vars(variable_args).items() if v is not None}
 
     # Merge variables in data files and command line arguments.


### PR DESCRIPTION
Add template argument instead.

The input option can still be used. In that case, the template
argument is considered part of the variables argument.