### PR TITLE
Positional arguments are better placed at the end

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -56,7 +56,7 @@ hello, world
 
 コマンド:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren - --help
+echo "{{ message }}, {{ name }}" | jiren --help -
 ```
 出力:
 ```
@@ -94,7 +94,7 @@ greeting:
   name: world
 EOF
 
-echo "{{ greeting.message }}, {{ greeting.name }}" | jiren - --data=data.yaml
+echo "{{ greeting.message }}, {{ greeting.name }}" | jiren --data=data.yaml -
 ```
 出力:
 ```
@@ -113,7 +113,7 @@ message: hello
 invalid_key: invalid
 EOF
 
-echo "{{ message }}" | jiren - --data=data.yaml --strict
+echo "{{ message }}" | jiren --data=data.yaml --strict -
 ```
 出力:
 ```
@@ -127,7 +127,7 @@ jiren: error: the data file contains unknown variables: invalid_key
 
 コマンド:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren - --required -- --message=hello
+echo "{{ message }}, {{ name }}" | jiren --required - -- --message=hello
 ```
 出力:
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can use the help to check the variables defined in a template.
 
 Command:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren - --help
+echo "{{ message }}, {{ name }}" | jiren --help -
 ```
 Outputs:
 ```
@@ -96,7 +96,7 @@ greeting:
   name: world
 EOF
 
-echo "{{ greeting.message }}, {{ greeting.name }}" | jiren - --data=data.yaml
+echo "{{ greeting.message }}, {{ greeting.name }}" | jiren --data=data.yaml -
 ```
 Outputs:
 ```
@@ -115,7 +115,7 @@ message: hello
 invalid_key: invalid
 EOF
 
-echo "{{ message }}" | jiren - --data=data.yaml --strict
+echo "{{ message }}" | jiren --data=data.yaml --strict -
 ```
 Outputs:
 ```
@@ -129,7 +129,7 @@ When using the `--required` option, you must specify values for all variables.
 
 Command:
 ```sh
-echo "{{ message }}, {{ name }}" | jiren - --required -- --message=hello
+echo "{{ message }}, {{ name }}" | jiren --required - -- --message=hello
 ```
 Outputs:
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def test_main_help(monkeypatch):
 
 
 def test_main_help_with_variables(monkeypatch):
-    command = "jiren - --help"
+    command = "jiren --help -"
     stdin = io.StringIO("{{ greeting }}")
     stdout = io.StringIO()
 
@@ -120,7 +120,7 @@ def test_main_with_json_data_file(monkeypatch, tmp_path):
     data_file = tmp_path / "data.json"
     data_file.write_text("{'greeting': {'message': 'hello', 'target': 'world'} }")
 
-    command = f"jiren - --data={data_file}"
+    command = f"jiren --data={data_file} -"
     stdin = io.StringIO("{{ greeting.message }}, {{ greeting.target }}")
     stdout = io.StringIO()
 
@@ -137,7 +137,7 @@ def test_main_with_yaml_data_file(monkeypatch, tmp_path):
     data_file = tmp_path / "data.yaml"
     data_file.write_text("greeting:\n  message: hello\n  target: world")
 
-    command = f"jiren - --data={data_file}"
+    command = f"jiren --data={data_file} -"
     stdin = io.StringIO("{{ greeting.message }}, {{ greeting.target }}")
     stdout = io.StringIO()
 
@@ -150,11 +150,28 @@ def test_main_with_yaml_data_file(monkeypatch, tmp_path):
     assert stdout.getvalue() == "hello, world\n"
 
 
+def test_main_with_data_file_and_arguments(monkeypatch, tmp_path):
+    data_file = tmp_path / "data.yaml"
+    data_file.write_text("message: hello")
+
+    command = f"jiren --data={data_file} - -- --message=hey --name=you"
+    stdin = io.StringIO("{{ message }}, {{ name }}")
+    stdout = io.StringIO()
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", command.split())
+        m.setattr("sys.stdin", stdin)
+        m.setattr("sys.stdout", stdout)
+        main()
+
+    assert stdout.getvalue() == "hey, you\n"
+
+
 def test_main_with_json_data_file_unknown_variables(monkeypatch, tmp_path):
     data_file = tmp_path / "data.json"
     data_file.write_text("{'a': 1, 'b': 2, 'c': 3}")
 
-    command = f"jiren - --data={data_file}"
+    command = f"jiren --data={data_file} -"
     stdin = io.StringIO("{{ greeting }}")
     stdout = io.StringIO()
 
@@ -171,7 +188,7 @@ def test_main_strictly_with_json_data_file_unknown_variables(monkeypatch, tmp_pa
     data_file = tmp_path / "data.json"
     data_file.write_text("{'a': 1, 'b': 2, 'c': 3}")
 
-    command = f"jiren - --data={data_file} --strict"
+    command = f"jiren --data={data_file} --strict -"
     stdin = io.StringIO("{{ greeting }}")
     stderr = io.StringIO()
 
@@ -190,7 +207,7 @@ def test_main_with_yaml_data_file_no_keys(monkeypatch, tmp_path):
     data_file = tmp_path / "data.yaml"
     data_file.write_text("hello")
 
-    command = f"jiren - --data={data_file}"
+    command = f"jiren --data={data_file} -"
     stdin = io.StringIO("{{ greeting }}")
     stderr = io.StringIO()
 
@@ -239,7 +256,7 @@ def test_main_with_required(monkeypatch, tmp_path):
     data_file = tmp_path / "data.yaml"
     data_file.write_text("greeting: hello")
 
-    command = f"jiren - --data={data_file} --required"
+    command = f"jiren --data={data_file} --required -"
     stdin = io.StringIO("{{ greeting }}")
     stdout = io.StringIO()
 
@@ -253,7 +270,7 @@ def test_main_with_required(monkeypatch, tmp_path):
 
 
 def test_main_with_no_required_variables(monkeypatch):
-    command = "jiren - --required"
+    command = "jiren --required -"
     stdin = io.StringIO("{{ greeting }}")
     stderr = io.StringIO()
 


### PR DESCRIPTION
Do not place a template argument before options. It is standard to
place the template argument immediately before the variables
argument (`--`).

OK:
```
$ echo "{{ message }}" | jiren --required - -- --message=hello
hello
```

NG:
```
$ echo "{{ message }}" | jiren - --required -- --message=hello
usage: jiren [-h] [-V] [--required] [--strict] [-i INPUT] [-d DATA] [template] [variables ...]
jiren: error: unrecognized arguments: -- --message=hello
```

Although complicated, this limitation is not affected if there is no
variables argument.

OK:
```
$ cat <<EOF >data.yaml
message: hello
EOF

$ echo "{{ message }}" | jiren - --data=data.yaml
hello
```