### PR TITLE
Remove capped dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,17 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = "~=3.7"
+requires-python = ">=3.7"
 dependencies = [
-    "jinja2~=3.0",
-    "pyyaml~=6.0",
+    "jinja2>=2.11",
+    "pyyaml>=5.3",
     "importlib-metadata>=1.4; python_version < '3.8'",
 ]
 
 [project.optional-dependencies]
 test = [
-    "pytest~=7.1",
-    "pytest-cov~=3.0",
+    "pytest",
+    "pytest-cov",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The upper versions of dependencies are not strictly necessary and
should be removed.