### PR TITLE
Use setup-python when building packages

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build
@@ -34,7 +39,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: ./pyproject.toml
+          cache-dependency-path: "**/pyproject.toml"
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "$(ls ./dist/jiren-*-py3-none-any.whl)[test]"
+          python3 -m pip install "$(ls ./dist/*-py3-none-any.whl | tail -1)[test]"
 
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 lint:
 	pre-commit run --all-files
 test:
-	python3 -m pytest -v ./tests
+	pytest -v ./tests
 build:
 	python3 -m pip install build
 	python3 -m build


### PR DESCRIPTION
This is because the default python environment has several packages
installed, which may cause version conflicts.