### PR TITLE
Get the correct version with GitHub Actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"


### PR DESCRIPTION
The checkout action, by default, only checks out the latest one commit, so it was not generating the correct version.

We changed it to fetch all commits when building a package by specifying the fetch-depth option.