### PR TITLE
Fix cache to be saved correctly

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build
@@ -41,7 +40,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Download artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
The definition of dependency packages was changed from pyproject.toml to requirements.txt, and the cache-dependency-path in the cache action was modified accordingly.

The cache-dependency-path of the cache action defaults to requirements.txt when pip is specified.