### PR TITLE
Disable dependabot for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
The version of the dependent package is not the latest, but the lower end of the supported version. dependabot tries to update to the latest version, so pip's dependent packages are excluded.